### PR TITLE
Fix error in right_rotate

### DIFF
--- a/trees/red_black_tree.py
+++ b/trees/red_black_tree.py
@@ -62,7 +62,7 @@ class RedBlackTree:
         elif x == x.p.right:
             x.p.right = y 
         else:
-            x.p.right = y 
+            x.p.left = y 
 
         y.right = x 
         x.p = y


### PR DESCRIPTION
Functions right_rotate and left_rotate should be symmetrical. So that we can replace left with right and vice versa and get the second function. This is not the case, so I think this is a mistake. I also tested it myself and after the fix, my code started working correctly.