### PR TITLE
Update DFS to use set

### DIFF
--- a/search/depth_first_search.py
+++ b/search/depth_first_search.py
@@ -12,6 +12,8 @@ graph = {
 
 
 def dfs(graph, node):
+    # the video has visited as an array. I changed this to set because 'n not in visited' is O(1) instead of O(n).
+    # see this link for more: https://wiki.python.org/moin/TimeComplexity.
     visited = set()
     stack = []
 

--- a/search/depth_first_search.py
+++ b/search/depth_first_search.py
@@ -11,7 +11,6 @@ graph = {
 }
 
 
-
 def dfs(graph, node):
     visited = set()
     stack = []

--- a/search/depth_first_search.py
+++ b/search/depth_first_search.py
@@ -11,11 +11,12 @@ graph = {
 }
 
 
+
 def dfs(graph, node):
-    visited = []
+    visited = set()
     stack = []
 
-    visited.append(node)
+    visited.add(node)
     stack.append(node) 
 
     while stack:
@@ -25,7 +26,7 @@ def dfs(graph, node):
         # reverse iterate through edge list so results match recursive version
         for n in reversed(graph[s]):
             if n not in visited:
-                visited.append(n)
+                visited.add(n)
                 stack.append(n)
 
 


### PR DESCRIPTION
Changing `visited` from a list to a set changes the `n not in visited` line to O(1) time instead of O(n), because it replaces a linear scan (in the case of a list) to a hash lookup (in the case of a set) which is O(1) time.

ref: https://github.com/msambol/dsa/issues/9